### PR TITLE
ST7735 Fixups

### DIFF
--- a/components/tft/tftspi.c
+++ b/components/tft/tftspi.c
@@ -757,19 +757,24 @@ void TFT_display_init()
 		commandList(disp_spi, ST7789V_init);
 	}
 	else if (tft_disp_type == DISP_TYPE_ST7735) {
+		ret = disp_select();
+		assert(ret==ESP_OK);
 		commandList(disp_spi, STP7735_init);
 	}
 	else if (tft_disp_type == DISP_TYPE_ST7735R) {
+		ret = disp_select();
+		assert(ret==ESP_OK);
 		commandList(disp_spi, STP7735R_init);
 		commandList(disp_spi, Rcmd2green);
 		commandList(disp_spi, Rcmd3);
 	}
 	else if (tft_disp_type == DISP_TYPE_ST7735B) {
+		ret = disp_select();
+		assert(ret==ESP_OK);
 		commandList(disp_spi, STP7735R_init);
 		commandList(disp_spi, Rcmd2red);
 		commandList(disp_spi, Rcmd3);
-	    uint8_t dt = 0xC0;
-		disp_select();
+		uint8_t dt = 0xC0;
 		disp_spi_transfer_cmd_data(TFT_MADCTL, &dt, 1);
 	}
 	else assert(0);

--- a/components/tft/tftspi.h
+++ b/components/tft/tftspi.h
@@ -387,11 +387,15 @@ static const uint8_t ILI9488_init[] = {
 // Initialization commands for 7735B screens
 // ------------------------------------
 static const uint8_t STP7735_init[] = {
-  17,						// 18 commands in list:
+#if PIN_NUM_RST
+  17,                   		// 17 commands in list
+#else
+  18,					// 18 commands in list:
   ST7735_SLPOUT ,   TFT_CMD_DELAY,	//  2: Out of sleep mode, no args, w/delay
   255,						//     255 = 500 ms delay
+#endif
   TFT_CMD_PIXFMT , 1+TFT_CMD_DELAY,	//  3: Set color mode, 1 arg + delay:
-  1, 0x06,							//     18-bit color 6-6-6 color format
+  0x06,						//     18-bit color 6-6-6 color format
   10,						//     10 ms delay
   ST7735_FRMCTR1, 3+TFT_CMD_DELAY,	//  4: Frame rate control, 3 args + delay:
   0x00,						//     fastest refresh
@@ -447,9 +451,13 @@ static const uint8_t STP7735_init[] = {
 // Init for 7735R, part 1 (red or green tab)
 // --------------------------------------
 static const uint8_t  STP7735R_init[] = {
-  15,						// 15 commands in list:
+#if PIN_NUM_RST
+  14,            			// 14 commands in list
+#else
+  15,					// 15 commands in list:
   ST7735_SWRESET,   TFT_CMD_DELAY,	//  1: Software reset, 0 args, w/delay
   150,						//     150 ms delay
+#endif
   ST7735_SLPOUT ,   TFT_CMD_DELAY,	//  2: Out of sleep mode, 0 args, w/delay
   255,						//     500 ms delay
   ST7735_FRMCTR1, 3      ,	//  3: Frame rate ctrl - normal mode, 3 args:


### PR DESCRIPTION
Hi loboris,
1) My ST7735 display works with DEFAULT_DISP_TYPE as DISP_TYPE_ILI9341 but does not work with DISP_TYPE_ST7735, DISP_TYPE_ST7735B, DISP_TYPE_ST7735R. I corrected the code and now my display works as DISP_TYPE_ST7735B and DISP_TYPE_ST7735R.
2) I think that the init sequence for 7735R in tftspi.c must be:
```
STP7735R_init
Rcmd2red  (not Rcmd2green)
Rcmd3
```
3) Also you can add new type 7735G with init sequence:
```
STP7735R_init
Rcmd2green
Rcmd3
```
but for Green Label some offsets should be released:
```
colstart = 2;
rowstart = 1;
```
Best regards
