### PR TITLE
Fix compile errors missing "driver/gpio.h"

### DIFF
--- a/components/tft/tftspi.c
+++ b/components/tft/tftspi.c
@@ -14,6 +14,7 @@
 #include "freertos/task.h"
 #include "esp_heap_caps.h"
 #include "soc/spi_reg.h"
+#include "driver/gpio.h"
 
 
 // ====================================================


### PR DESCRIPTION

```
/home/seungcheol/work/esp32/leeseungcheol/ESP32_TFT_library/components/tft/tftspi.c: In function 'disp_spi_transfer_cmd':
/home/seungcheol/work/esp32/leeseungcheol/ESP32_TFT_library/components/tft/tftspi.c:120:5: error: implicit declaration of function 'gpio_set_level' [-Werror=implicit-function-declaration]
     gpio_set_level(PIN_NUM_DC, 0);
     ^
/home/seungcheol/work/esp32/leeseungcheol/ESP32_TFT_library/components/tft/tftspi.c: In function 'TFT_PinsInit':
/home/seungcheol/work/esp32/leeseungcheol/ESP32_TFT_library/components/tft/tftspi.c:863:5: error: implicit declaration of function 'gpio_pad_select_gpio' [-Werror=implicit-function-declaration]
     gpio_pad_select_gpio(PIN_NUM_CS);
     ^
/home/seungcheol/work/esp32/leeseungcheol/ESP32_TFT_library/components/tft/tftspi.c:869:5: error: implicit declaration of function 'gpio_set_direction' [-Werror=implicit-function-declaration]
     gpio_set_direction(PIN_NUM_MISO, GPIO_MODE_INPUT);
     ^
/home/seungcheol/work/esp32/leeseungcheol/ESP32_TFT_library/components/tft/tftspi.c:869:28: error: 'GPIO_MODE_INPUT' undeclared (first use in this function)
     gpio_set_direction(PIN_NUM_MISO, GPIO_MODE_INPUT);
                            ^
/home/seungcheol/work/esp32/leeseungcheol/ESP32_TFT_library/components/tft/tftspi.c:869:28: note: each undeclared identifier is reported only once for each function it appears in
/home/seungcheol/work/esp32/leeseungcheol/ESP32_TFT_library/components/tft/tftspi.c:870:5: error: implicit declaration of function 'gpio_set_pull_mode' [-Werror=implicit-function-declaration]
     gpio_set_pull_mode(PIN_NUM_MISO, GPIO_PULLUP_ONLY);
     ^
/home/seungcheol/work/esp32/leeseungcheol/ESP32_TFT_library/components/tft/tftspi.c:870:28: error: 'GPIO_PULLUP_ONLY' undeclared (first use in this function)
     gpio_set_pull_mode(PIN_NUM_MISO, GPIO_PULLUP_ONLY);
                            ^
/home/seungcheol/work/esp32/leeseungcheol/ESP32_TFT_library/components/tft/tftspi.c:871:27: error: 'GPIO_MODE_OUTPUT' undeclared (first use in this function)
     gpio_set_direction(PIN_NUM_CS, GPIO_MODE_OUTPUT);
```