### PR TITLE
Compile errors with current esp-idf mitigated. ESP-WROVER-KIT 4.1 menuconfig option added.

### DIFF
--- a/components/spiffs/spiffs_nucleus.c
+++ b/components/spiffs/spiffs_nucleus.c
@@ -679,7 +679,7 @@ static s32_t spiffs_populate_ix_map_v(
   res = _spiffs_rd(fs, SPIFFS_OP_T_OBJ_LU2 | SPIFFS_OP_C_READ,
       0, SPIFFS_PAGE_TO_PADDR(fs, pix), sizeof(spiffs_page_object_ix), (u8_t *)objix);
   SPIFFS_CHECK_RES(res);
-  SPIFFS_VALIDATE_OBJIX(objix->p_hdr, obj_id, objix->p_hdr.span_ix);
+  //SPIFFS_VALIDATE_OBJIX(objix->p_hdr, obj_id, objix->p_hdr.span_ix);
 
   // check if hdr is ok, and if objix range overlap with ix map range
   if ((objix->p_hdr.flags & (SPIFFS_PH_FLAG_DELET | SPIFFS_PH_FLAG_FINAL | SPIFFS_PH_FLAG_IXDELE)) ==

--- a/components/tft/tftspi.c
+++ b/components/tft/tftspi.c
@@ -2,7 +2,7 @@
  *  Author: LoBo (loboris@gmail.com, loboris.github)
  *
  *  Module supporting SPI TFT displays based on ILI9341 & ILI9488 controllers
- * 
+ *
  * HIGH SPEED LOW LEVEL DISPLAY FUNCTIONS
  * USING DIRECT or DMA SPI TRANSFER MODEs
  *
@@ -14,6 +14,7 @@
 #include "freertos/task.h"
 #include "esp_heap_caps.h"
 #include "soc/spi_reg.h"
+#include "driver/gpio.h"
 
 
 // ====================================================
@@ -162,7 +163,7 @@ void IRAM_ATTR disp_spi_transfer_cmd_data(int8_t cmd, uint8_t *data, uint32_t le
     	if (idx == 16) {
     		// SPI buffer full, send data
 			_spi_transfer_start(disp_spi, bits, 0);
-    		
+
 			bits = 0;
     		idx = 0;
 			bidx = 0;
@@ -875,7 +876,7 @@ void TFT_PinsInit()
 #if USE_TOUCH
     gpio_pad_select_gpio(PIN_NUM_TCS);
     gpio_set_direction(PIN_NUM_TCS, GPIO_MODE_OUTPUT);
-#endif    
+#endif
 #if PIN_NUM_BCKL
     gpio_pad_select_gpio(PIN_NUM_BCKL);
     gpio_set_direction(PIN_NUM_BCKL, GPIO_MODE_OUTPUT);

--- a/components/tft/tftspi.h
+++ b/components/tft/tftspi.h
@@ -1,5 +1,5 @@
 /*
- * 
+ *
  * HIGH SPEED LOW LEVEL DISPLAY FUNCTIONS USING DIRECT TRANSFER MODE
  *
 */
@@ -38,7 +38,7 @@
 
 #if CONFIG_EXAMPLE_DISPLAY_TYPE == 1
 
-// ** Set the correct configuration for ESP32-WROVER-KIT v3
+// ** Set the correct configuration for ESP-WROVER-KIT v3
 // --------------------------------------------------------
 #define DEFAULT_DISP_TYPE           DISP_TYPE_ST7789V
 #define DEFAULT_TFT_DISPLAY_WIDTH   240
@@ -123,6 +123,36 @@
 #define PIN_BCKL_ON  1  	// GPIO value for backlight ON
 #define PIN_BCKL_OFF 0  	// GPIO value for backlight OFF
 // ---------------------------------------------------------
+
+#elif CONFIG_EXAMPLE_DISPLAY_TYPE == 4
+
+// ** Set the correct configuration for ESP-WROVER-KIT v4.1
+// --------------------------------------------------------
+#define DEFAULT_DISP_TYPE           DISP_TYPE_ILI9341
+#define DEFAULT_TFT_DISPLAY_WIDTH   240
+#define DEFAULT_TFT_DISPLAY_HEIGHT  320
+#define DISP_COLOR_BITS_24          0x66
+#define DEFAULT_GAMMA_CURVE         0
+#define DEFAULT_SPI_CLOCK           26000000
+#define TFT_INVERT_ROTATION         0
+#define TFT_INVERT_ROTATION1        0
+#define TFT_INVERT_ROTATION2        0
+#define TFT_RGB_BGR                 0x08
+
+#define USE_TOUCH   TOUCH_TYPE_NONE
+
+#define PIN_NUM_MISO 25     // SPI MISO
+#define PIN_NUM_MOSI 23     // SPI MOSI
+#define PIN_NUM_CLK  19     // SPI CLOCK pin
+#define PIN_NUM_CS   22     // Display CS pin
+#define PIN_NUM_DC   21     // Display command/data pin
+#define PIN_NUM_TCS   0     // Touch screen CS pin
+
+#define PIN_NUM_RST  18     // GPIO used for RESET control
+#define PIN_NUM_BCKL  5     // GPIO used for backlight control
+#define PIN_BCKL_ON   0     // GPIO value for backlight ON
+#define PIN_BCKL_OFF  1     // GPIO value for backlight OFF
+// --------------------------------------------------------
 
 #else
 

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -30,17 +30,20 @@ config EXAMPLE_DISPLAY_TYPE
     default 1 if EXAMPLE_DISPLAY_TYPE1
     default 2 if EXAMPLE_DISPLAY_TYPE2
     default 3 if EXAMPLE_DISPLAY_TYPE3
+    default 4 if EXAMPLE_DISPLAY_TYPE4
 
     choice
         prompt "Select predefined display configuration"
         default EXAMPLE_DISPLAY_TYPE0
         help
             Select predefined display configuration
-    
+
         config EXAMPLE_DISPLAY_TYPE0
             bool "None"
         config EXAMPLE_DISPLAY_TYPE1
-            bool "ESP-WROVER-KIT Display"
+            bool "ESP-WROVER-KIT v3 Display (ST7789V)"
+        config EXAMPLE_DISPLAY_TYPE4
+            bool "ESP-WROVER-KIT v4.1 Display (ILI9341)"
         config EXAMPLE_DISPLAY_TYPE2
             bool "Adafruit TFT Feather display"
         config EXAMPLE_DISPLAY_TYPE3


### PR DESCRIPTION
Just two small changes to let the project compile again.

Support for ESP-WROVER-KIT 4.1 Display was added. Display  invertation removed.